### PR TITLE
Implement release strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To use non-default branch names:
 
 ```yaml
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@{commit SHA}
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@<commit-sha>
         with:
           main_branch: master
           develop_branch: staging

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Automatically creates or updates a release PR from `develop` → `main`. Each ti
 
 #### Usage
 
-Pin to a specific commit SHA for supply-chain safety — unlike branch or tag refs, a SHA is immutable.
+Pin to a specific commit SHA for supply-chain safety — branch and tag refs can be moved, but a commit SHA is immutable.
 You can find the latest commit sha in the commit history.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@{commit SHA}
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@<commit-sha>
 ```
 
 To use non-default branch names:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Automatically creates or updates a release PR from `develop` → `main`. Each ti
 
 #### Usage
 
+Pin to a specific commit SHA for supply-chain safety — unlike branch or tag refs, a SHA is immutable.
+You can find the latest commit sha in the commit history.
+
 ```yaml
 # .github/workflows/release-pr.yml
 name: Release PR
@@ -38,14 +41,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.0
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@{commit SHA}
 ```
 
 To use non-default branch names:
 
 ```yaml
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.0
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@{commit SHA}
         with:
           main_branch: master
           develop_branch: staging
@@ -57,16 +60,3 @@ To use non-default branch names:
 | ---------------- | --------- | ---------------------------- |
 | `main_branch`    | `main`    | The branch to release into   |
 | `develop_branch` | `develop` | The branch being released    |
-
-## Releasing New Action Versions
-
-Actions in this repo are versioned with git tags. Consumer repos pin to a specific tag (e.g. `@v1.0.0`) rather than `@main` for supply-chain safety.
-
-To cut a new release:
-
-```bash
-git tag v1.1.0
-git push origin v1.1.0
-```
-
-For breaking changes, bump the major version (`v2.0.0`) and update the usage example in this README. Consumer repos opt in by updating their `uses:` line.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Automatically creates or updates a release PR from `develop` → `main`. Each ti
 
 #### Usage
 
-Pin to a specific commit SHA for supply-chain safety — branch and tag refs can be moved, but a commit SHA is immutable.
-You can find the latest commit sha in the commit history.
+Pin to a published release tag for supply-chain safety. Published GitHub releases are immutable — the tag cannot be moved or deleted. Find available releases on the [releases page](https://github.com/resident-advisor/.github/releases).
 
 ```yaml
 # .github/workflows/release-pr.yml
@@ -41,14 +40,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@<commit-sha>
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.0
 ```
 
 To use non-default branch names:
 
 ```yaml
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@<commit-sha>
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.0
         with:
           main_branch: master
           develop_branch: staging
@@ -60,3 +59,29 @@ To use non-default branch names:
 | ---------------- | --------- | ---------------------------- |
 | `main_branch`    | `main`    | The branch to release into   |
 | `develop_branch` | `develop` | The branch being released    |
+
+## Releasing New Action Versions
+
+Releases are created using `scripts/release.sh`, which tags the current commit and opens a draft GitHub release. Publishing the release makes the tag immutable.
+
+### Prerequisites
+
+- [git](https://git-scm.com/)
+- [GitHub CLI](https://cli.github.com/) — install with `brew install gh`
+- Authenticated with the GitHub CLI: `gh auth login`
+
+### Steps
+
+From `main` with a clean working directory:
+
+```bash
+# You should use semantic versioning to decide what version to pass
+./scripts/release.sh v1.1.0
+```
+
+The script will confirm the version, branch, and commit before doing anything. Once confirmed it will:
+
+1. Create and push the tag
+2. Open a draft release in GitHub
+
+Add release notes to the draft, then publish it. Consumer repos update their `uses:` tag to pick up the new version.

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@main
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.0
 ```
 
 To use non-default branch names:
 
 ```yaml
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@main
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.0
         with:
           main_branch: master
           develop_branch: staging
@@ -57,3 +57,16 @@ To use non-default branch names:
 | ---------------- | --------- | ---------------------------- |
 | `main_branch`    | `main`    | The branch to release into   |
 | `develop_branch` | `develop` | The branch being released    |
+
+## Releasing New Action Versions
+
+Actions in this repo are versioned with git tags. Consumer repos pin to a specific tag (e.g. `@v1.0.0`) rather than `@main` for supply-chain safety.
+
+To cut a new release:
+
+```bash
+git tag v1.1.0
+git push origin v1.1.0
+```
+
+For breaking changes, bump the major version (`v2.0.0`) and update the usage example in this README. Consumer repos opt in by updating their `uses:` line.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,7 +62,7 @@ read -r -p "Create and push tag '$VERSION', then open a draft release? [y/N] " c
 
 echo ""
 echo "→ Creating tag $VERSION..."
-git tag "$VERSION"
+git tag -a "$VERSION" -m "$VERSION"
 
 echo "→ Pushing tag to origin..."
 git push origin "$VERSION"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,8 +43,8 @@ if [[ "$CURRENT_BRANCH" != "main" ]]; then
   [[ "$confirm" =~ ^[Yy]$ ]] || exit 1
 fi
 
-if git rev-parse "$VERSION" &>/dev/null; then
-  echo "Error: tag '$VERSION' already exists."
+if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" &>/dev/null; then
+  echo "Error: tag '$VERSION' already exists on origin."
   exit 1
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# release.sh — create an immutable draft GitHub release
+# release.sh — create a version tag and draft GitHub release
 #
 # Usage: ./release.sh <version>
 #   e.g. ./release.sh v1.2.0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -80,7 +80,7 @@ echo "✓ Done. Draft release created for $VERSION."
 echo ""
 echo "Next steps:"
 echo "  1. Open the draft release in GitHub and add your release notes."
-echo "  2. Click 'Publish release' — it will become immutable immediately."
+echo "  2. Click 'Publish release' — then treat the tag as immutable (and ensure tags are protected if you need enforcement)."
 echo ""
 
 # Open the release in the browser for convenience

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# release.sh — create an immutable draft GitHub release
+#
+# Usage: ./release.sh <version>
+#   e.g. ./release.sh v1.2.0
+#
+# Requires: git, gh (GitHub CLI), authenticated via `gh auth login`
+# ---------------------------------------------------------------------------
+
+VERSION="${1:-}"
+
+# --- validate input ---------------------------------------------------------
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>  (e.g. $0 v1.2.0)"
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: version must be in the format vX.Y.Z (got '$VERSION')"
+  exit 1
+fi
+
+# --- pre-flight checks ------------------------------------------------------
+
+if ! gh auth status &>/dev/null; then
+  echo "Error: not authenticated with GitHub CLI. Run: gh auth login"
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: working directory is dirty. Commit or stash your changes first."
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "Warning: you are on '$CURRENT_BRANCH', not 'main'."
+  read -r -p "Continue anyway? [y/N] " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || exit 1
+fi
+
+if git rev-parse "$VERSION" &>/dev/null; then
+  echo "Error: tag '$VERSION' already exists."
+  exit 1
+fi
+
+# --- confirm before doing anything ------------------------------------------
+
+echo ""
+echo "  Version : $VERSION"
+echo "  Branch  : $CURRENT_BRANCH"
+echo "  Commit  : $(git rev-parse --short HEAD)"
+echo ""
+read -r -p "Create and push tag '$VERSION', then open a draft release? [y/N] " confirm
+[[ "$confirm" =~ ^[Yy]$ ]] || exit 1
+
+# --- tag and push -----------------------------------------------------------
+
+echo ""
+echo "→ Creating tag $VERSION..."
+git tag "$VERSION"
+
+echo "→ Pushing tag to origin..."
+git push origin "$VERSION"
+
+# --- create draft release ---------------------------------------------------
+
+echo "→ Creating draft release on GitHub..."
+gh release create "$VERSION" \
+  --draft \
+  --title "$VERSION" \
+  --notes "<!-- Add release notes here before publishing -->"
+
+echo ""
+echo "✓ Done. Draft release created for $VERSION."
+echo ""
+echo "Next steps:"
+echo "  1. Open the draft release in GitHub and add your release notes."
+echo "  2. Click 'Publish release' — it will become immutable immediately."
+echo ""
+
+# Open the release in the browser for convenience
+gh release view "$VERSION" --web


### PR DESCRIPTION
Add a release strategy for shared actions.

AI generated a simple release script which uses the github cli to generate an [immutable release](https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/) on github (I enabled this in the repo settings).

This means we can correctly version shared actions, and tagged release branches are immutable.
This means co pilot won't complain about us accidentally running mutable code (well it might not know that these are immutable releases and still complain, but we can know its wrong!)