### PR TITLE
Add valid version numbers to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.0
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.1
 ```
 
 To use non-default branch names:
 
 ```yaml
     steps:
-      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.0
+      - uses: resident-advisor/.github/.github/actions/release-pr-bot@v1.0.1
         with:
           main_branch: master
           develop_branch: staging


### PR DESCRIPTION
Realized there actually isn't a v1.0.0 (this was accidentally created with nothing in it when testing immutable release tags).

Just changing the readme to have a valid version number in it so people can just copy and paste the code example :)