### PR TITLE
Don't retag people who have already approved the PR

### DIFF
--- a/.github/actions/release-pr-bot/manage-release-pr.js
+++ b/.github/actions/release-pr-bot/manage-release-pr.js
@@ -129,28 +129,27 @@ async function updateReleasePR({ github, owner, repo, pr, body, reviewers }) {
 
   await github.rest.pulls.update({ owner, repo, pull_number: pr.number, body })
 
-  const { data: currentReviews } =
-    await github.rest.pulls.listRequestedReviewers({
-      owner,
-      repo,
-      pull_number: pr.number,
-    })
+  const [{ data: currentReviews }, { data: submittedReviews }] =
+    await Promise.all([
+      github.rest.pulls.listRequestedReviewers({
+        owner,
+        repo,
+        pull_number: pr.number,
+      }),
+      github.rest.pulls.listReviews({
+        owner,
+        repo,
+        pull_number: pr.number,
+      }),
+    ])
 
-  const { data: submittedReviews } = await github.rest.pulls.listReviews({
-    owner,
-    repo,
-    pull_number: pr.number,
-  })
-
-  const currentLogins = new Set(currentReviews.users.map((u) => u.login))
-  const approvers = new Set(
-    submittedReviews
+  const excludedLogins = new Set([
+    ...currentReviews.users.map((u) => u.login),
+    ...submittedReviews
       .filter((review) => review.state === 'APPROVED')
       .map((review) => review.user?.login),
-  )
-  const newReviewers = reviewers.filter(
-    (r) => !currentLogins.has(r) && !approvers.has(r),
-  )
+  ])
+  const newReviewers = reviewers.filter((r) => !excludedLogins.has(r))
 
   if (newReviewers.length > 0) {
     await github.rest.pulls.requestReviewers({

--- a/.github/actions/release-pr-bot/manage-release-pr.js
+++ b/.github/actions/release-pr-bot/manage-release-pr.js
@@ -136,8 +136,21 @@ async function updateReleasePR({ github, owner, repo, pr, body, reviewers }) {
       pull_number: pr.number,
     })
 
+  const { data: submittedReviews } = await github.rest.pulls.listReviews({
+    owner,
+    repo,
+    pull_number: pr.number,
+  })
+
   const currentLogins = new Set(currentReviews.users.map((u) => u.login))
-  const newReviewers = reviewers.filter((r) => !currentLogins.has(r))
+  const approvers = new Set(
+    submittedReviews
+      .filter((review) => review.state === 'APPROVED')
+      .map((review) => review.user?.login),
+  )
+  const newReviewers = reviewers.filter(
+    (r) => !currentLogins.has(r) && !approvers.has(r),
+  )
 
   if (newReviewers.length > 0) {
     await github.rest.pulls.requestReviewers({

--- a/.github/actions/release-pr-bot/manage-release-pr.test.js
+++ b/.github/actions/release-pr-bot/manage-release-pr.test.js
@@ -7,6 +7,7 @@ const makeGithub = ({
   mergedPRs = [],
   openPRs = [],
   currentReviewers = [],
+  submittedReviews = [],
 } = {}) => ({
   rest: {
     repos: {
@@ -17,6 +18,7 @@ const makeGithub = ({
       create: jest.fn().mockResolvedValue({ data: { number: 99, html_url: 'https://github.com/test/pull/99' } }),
       update: jest.fn().mockResolvedValue({}),
       listRequestedReviewers: jest.fn().mockResolvedValue({ data: { users: currentReviewers } }),
+      listReviews: jest.fn().mockResolvedValue({ data: submittedReviews }),
       requestReviewers: jest.fn().mockResolvedValue({}),
     },
   },
@@ -85,6 +87,20 @@ describe('manage-release-pr', () => {
       mergedPRs: [unreleasedPR],
       openPRs: [{ number: 42 }],
       currentReviewers: [{ login: 'alice' }],
+    })
+
+    await run({ github, context: makeContext() })
+
+    expect(github.rest.pulls.requestReviewers).not.toHaveBeenCalled()
+  })
+
+  it('does not re-request reviews from people who already approved', async () => {
+    const github = makeGithub({
+      commits: [{ sha: 'abc123' }],
+      mergedPRs: [unreleasedPR],
+      openPRs: [{ number: 42 }],
+      currentReviewers: [],
+      submittedReviews: [{ user: { login: 'alice' }, state: 'APPROVED' }],
     })
 
     await run({ github, context: makeContext() })


### PR DESCRIPTION
[//]: # "Please update your PR to have a descriptive title rather than an auto-generated one, this makes it easier to read in git history and when linked to on other platforms."

### Background :scroll:

There was an issue where approvers were getting retagged on release PRs, this was making it hard to track who has approved a release and who hasn't.

[//]: # "A short explanation of how these changes relate to the linked story and/or any other reasons for opening this PR. Please assume that readers don't have any background knowledge relating to your changes."

### Changes :memo:

Just added some code to filter out people who have already approved the PR.

[//]: # "Bullet points summarising what you've changed."

### Screenshots :camera:

[//]: # "(Optional) If you've changed the design of a page/component, include screenshots so other developers have something to reference when looking at the code."

### Checklist :white_check_mark:

[//]: # "These are just things that are easy to forget, not hoops to jump through. Not all of these will be applicable for every PR."

- [x] Documentation updated (if appropriate)
- [x] Feature switches / experiments correctly configured in [Unleash](https://eu.app.unleash-hosted.com/eubb7016/projects/default)
- [x] Queries updated on [Notion](https://www.notion.so/resident-advisor/Shared-Queries-Knowledge-Base-207202402415800e9846ccd0b8e4748a?source=copy_link)
