### PR TITLE
Fix release PR review re-requests for stale commits

### DIFF
--- a/.github/actions/release-pr-bot/manage-release-pr.js
+++ b/.github/actions/release-pr-bot/manage-release-pr.js
@@ -143,12 +143,23 @@ async function updateReleasePR({ github, owner, repo, pr, body, reviewers }) {
       }),
     ])
 
-  const excludedLogins = new Set([
-    ...currentReviews.users.map((u) => u.login),
-    ...submittedReviews
-      .filter((review) => review.state === 'APPROVED')
-      .map((review) => review.user?.login),
-  ])
+  const excludedLogins = new Set(currentReviews.users.map((u) => u.login))
+  const staleApprovers = new Set()
+
+  const latestReviewByLogin = new Map()
+  for (const review of submittedReviews) {
+    const login = review.user?.login
+    if (login) latestReviewByLogin.set(login, review)
+  }
+  for (const [login, review] of latestReviewByLogin) {
+    if (review.state !== 'APPROVED') continue
+    if (review.commit_id === pr.head.sha) {
+      excludedLogins.add(login)
+    } else {
+      staleApprovers.add(login)
+    }
+  }
+
   const newReviewers = reviewers.filter((r) => !excludedLogins.has(r))
 
   if (newReviewers.length > 0) {
@@ -158,6 +169,12 @@ async function updateReleasePR({ github, owner, repo, pr, body, reviewers }) {
       pull_number: pr.number,
       reviewers: newReviewers,
     })
+    const reRequested = newReviewers.filter((r) => staleApprovers.has(r))
+    if (reRequested.length > 0) {
+      console.log(
+        `Re-requested review from ${reRequested.join(', ')} (new commits since their approval)`,
+      )
+    }
     console.log(`Added reviewers: ${newReviewers.join(', ')}`)
   }
 

--- a/.github/actions/release-pr-bot/manage-release-pr.js
+++ b/.github/actions/release-pr-bot/manage-release-pr.js
@@ -146,19 +146,20 @@ async function updateReleasePR({ github, owner, repo, pr, body, reviewers }) {
   const excludedLogins = new Set(currentReviews.users.map((u) => u.login))
   const staleApprovers = new Set()
 
-  const latestReviewByLogin = new Map()
-  for (const review of submittedReviews) {
+  const latestReviewByLogin = submittedReviews.reduce((map, review) => {
     const login = review.user?.login
-    if (login) latestReviewByLogin.set(login, review)
-  }
-  for (const [login, review] of latestReviewByLogin) {
-    if (review.state !== 'APPROVED') continue
+    if (login) map.set(login, review)
+    return map
+  }, new Map())
+
+  Array.from(latestReviewByLogin.entries()).forEach(([login, review]) => {
+    if (review.state !== 'APPROVED') return
     if (review.commit_id === pr.head.sha) {
       excludedLogins.add(login)
     } else {
       staleApprovers.add(login)
     }
-  }
+  })
 
   const newReviewers = reviewers.filter((r) => !excludedLogins.has(r))
 

--- a/.github/actions/release-pr-bot/manage-release-pr.test.js
+++ b/.github/actions/release-pr-bot/manage-release-pr.test.js
@@ -145,6 +145,36 @@ describe('manage-release-pr', () => {
     expect(github.rest.pulls.requestReviewers).not.toHaveBeenCalled()
   })
 
+  it('re-requests review only from the person whose approval went stale after a new commit', async () => {
+    const bobPR = {
+      number: 2,
+      title: 'Add feature',
+      merged_at: '2024-01-02T00:00:00Z',
+      merge_commit_sha: 'def456',
+      user: { login: 'bob' },
+    }
+
+    const github = makeGithub({
+      commits: [{ sha: 'abc123' }, { sha: 'def456' }],
+      mergedPRs: [unreleasedPR, bobPR],
+      openPRs: [{ number: 42, head: { sha: 'head-sha-2' } }],
+      currentReviewers: [],
+      submittedReviews: [
+        // alice reviewed before her second commit landed - now stale
+        { user: { login: 'alice' }, state: 'APPROVED', commit_id: 'head-sha-1' },
+        // bob reviewed after that commit landed - still current
+        { user: { login: 'bob' }, state: 'APPROVED', commit_id: 'head-sha-2' },
+      ],
+    })
+
+    await run({ github, context: makeContext() })
+
+    expect(github.rest.pulls.requestReviewers).toHaveBeenCalledTimes(1)
+    expect(github.rest.pulls.requestReviewers).toHaveBeenCalledWith(
+      expect.objectContaining({ pull_number: 42, reviewers: ['alice'] }),
+    )
+  })
+
   it('excludes bots from reviewers', async () => {
     const github = makeGithub({
       commits: [{ sha: 'abc123' }],

--- a/.github/actions/release-pr-bot/manage-release-pr.test.js
+++ b/.github/actions/release-pr-bot/manage-release-pr.test.js
@@ -94,13 +94,50 @@ describe('manage-release-pr', () => {
     expect(github.rest.pulls.requestReviewers).not.toHaveBeenCalled()
   })
 
-  it('does not re-request reviews from people who already approved', async () => {
+  it('does not re-request reviews from people who already approved the current commit', async () => {
     const github = makeGithub({
       commits: [{ sha: 'abc123' }],
       mergedPRs: [unreleasedPR],
-      openPRs: [{ number: 42 }],
+      openPRs: [{ number: 42, head: { sha: 'head-sha-1' } }],
       currentReviewers: [],
-      submittedReviews: [{ user: { login: 'alice' }, state: 'APPROVED' }],
+      submittedReviews: [
+        { user: { login: 'alice' }, state: 'APPROVED', commit_id: 'head-sha-1' },
+      ],
+    })
+
+    await run({ github, context: makeContext() })
+
+    expect(github.rest.pulls.requestReviewers).not.toHaveBeenCalled()
+  })
+
+  it('re-requests review from someone who approved a stale commit', async () => {
+    const github = makeGithub({
+      commits: [{ sha: 'abc123' }],
+      mergedPRs: [unreleasedPR],
+      openPRs: [{ number: 42, head: { sha: 'head-sha-2' } }],
+      currentReviewers: [],
+      submittedReviews: [
+        { user: { login: 'alice' }, state: 'APPROVED', commit_id: 'head-sha-1' },
+      ],
+    })
+
+    await run({ github, context: makeContext() })
+
+    expect(github.rest.pulls.requestReviewers).toHaveBeenCalledWith(
+      expect.objectContaining({ pull_number: 42, reviewers: ['alice'] }),
+    )
+  })
+
+  it('uses the latest review per person when they reviewed more than once', async () => {
+    const github = makeGithub({
+      commits: [{ sha: 'abc123' }],
+      mergedPRs: [unreleasedPR],
+      openPRs: [{ number: 42, head: { sha: 'head-sha-1' } }],
+      currentReviewers: [],
+      submittedReviews: [
+        { user: { login: 'alice' }, state: 'APPROVED', commit_id: 'stale-sha' },
+        { user: { login: 'alice' }, state: 'APPROVED', commit_id: 'head-sha-1' },
+      ],
     })
 
     await run({ github, context: makeContext() })


### PR DESCRIPTION
### Background :scroll:

The release PR bot was not properly handling cases where reviewers had approved previous commits but the PR head had moved forward. It would incorrectly exclude these reviewers from re-request lists, even though their approval was no longer valid for the current commit.

### Changes :memo:

- Modified review tracking logic to compare reviewer approvals against the current PR head commit SHA
- Reviewers who approved the current commit are excluded from re-requests (as intended)
- Reviewers who approved stale commits are now re-requested to review the new changes
- Added logic to track the latest review per person when multiple reviews exist from the same reviewer
- Added console logging to distinguish between newly added reviewers and those being re-requested due to stale approvals
- Updated test cases to verify the new behavior with explicit commit SHAs

### Checklist :white_check_mark:

- [x] Tests updated to cover new commit-based approval tracking
- [x] Existing tests pass with the new logic

https://claude.ai/code/session_01HwygAUrQrgCXADGUVPKEgf